### PR TITLE
integration of basic auth, gpas only logic, init check digit validation

### DIFF
--- a/CheckDigit.php
+++ b/CheckDigit.php
@@ -1,0 +1,73 @@
+<?php
+namespace meDIC\PseudoService;
+
+class CheckDigit extends PseudoService {
+    
+    /**
+     * @author Egidia Cenko
+     * @param string $known_id patient ID
+     * @access public
+     * @return boolean valid?
+     */
+    public static function validateID($known_id){
+        // no IDs with leading 0 exist 
+        if (strlen($known_id) === 10 && $known_id[0] != "0") {
+            return true;
+        } else {
+            return false;
+        }
+
+        /* initial logic when both 9 digits and 10 digits input is allowed
+        if (strlen($known_id) === 9 && $known_id[0] == "0") {
+            return false;
+        } else {
+            if (strlen($known_id) === 10 && $known_id[0] != "0") {
+                // 10 digits with pat id and check digit -> ideal
+                //TODO compare check digit from input to calculated one
+                return true;
+            } elseif (strlen($known_id) === 9 && $known_id[0] != "0") {
+                //TODO: calculate check digit for the provided ID
+                echo "9 Ziffern ohne Prüfziffer, muss berechnet werden";
+                return $known_id;
+
+            } elseif (strlen($known_id) === 10 && $known_id[0] == "0") {
+                //TODO: calculate check digit for the provided ID by trimming the leading 0
+                echo "10 Ziffern mit 0 am Anfang, muss berechnet werden";
+                return $known_id;
+            }
+        }*/
+    } 
+
+    //TODO: logic for check digit acc. to DIN ISO 7064
+    public static function calculateCheckDigit($known_id){
+        $digits = str_split($knownID);
+
+        //TODO: add case: if (strlen($known_id) === 10 && $known_id[0] != "0")
+        if (strlen($known_id) === 9 && $known_id[0] != "0") {
+            //TODO: calculate check digit for the provided ID
+            // add leading zero to 9-digits input
+            array_unshift($digits, "0");
+        } elseif (strlen($known_id) === 10 && $known_id[0] == "0") {
+            //TODO: calculate check digit for the provided ID by trimming the leading 0
+            echo "10 Ziffern mit 0 am Anfang, muss berechnet werden";
+            // 10 digits, leading 0 -> remains unchanged for calculation
+        }  
+         //TODO: compare logic for existing check digit and calculated one: i.e. for 10 digits without leading zero, split check digit and add leading zero to compare in validate
+        
+        if (count($digits) !== 10) {
+            throw new RuntimeException("Length mismatch after processing: " . implode("", $digits));
+        }
+
+        // logic for check digit acc. to DIN ISO 7064
+        $P = 10;
+        foreach ($digits as $char) {
+            $P += intval($char);
+            if ($P > 10) $P -= 10;
+            $P *= 2;
+            if ($P >= 11) $P -= 11;
+        }
+        
+        $checkDigit = 11 - $P;
+        return $checkDigit === 10 ? 0 : $checkDigit;
+    }
+}

--- a/PseudoService.php
+++ b/PseudoService.php
@@ -199,6 +199,14 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
                 exit($e->getMessage());
             }
         }
+
+        // redirect to data entry page after login
+        // ! moved from index.php because of wrong redirect in basic auth logic
+        if (isset($_SESSION[$oSAPPatientSearch->session]['redirect'])) {
+            $redirect = $_SESSION[$oSAPPatientSearch->session]['redirect'];
+            unset($_SESSION[$oSAPPatientSearch->session]['redirect']);
+            redirect(APP_PATH_WEBROOT."DataEntry/index.php?".$redirect);
+        }
     }
 
     /**
@@ -258,8 +266,6 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
         }
         if (strlen($url) == 0) return (false);
 
-        echo "von soapCall aus die die url: ". $url . " <-done und Service " . $psService . " <-";
-
         // set core curl options
         $curl_options = array(
             CURLOPT_URL => $url,
@@ -286,7 +292,7 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
             // TODO change UI fields for basic auth 
             $user_pw = $this->client_id . ":" . $this->client_secret;
 
-            //TODO: update according to epix and sap credentials
+            //TODO: update according to sap credentials
             $curl_options[CURLOPT_HTTPHEADER] = array("content-type: text/xml; charset=utf-8","Authorization:Basic " . base64_encode($user_pw));
         }
         // debug

--- a/PseudoService.php
+++ b/PseudoService.php
@@ -48,11 +48,9 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
         $this->authorization_url = $this->getSystemSetting("authorization_url");
         $this->client_id = $this->getSystemSetting("client_id");       // The client ID assigned to you by the provider
         $this->client_secret = $this->getSystemSetting("secret");      // The client password assigned to you by the provider
-        $this->login_option = $this->getSystemSetting("login_option"); // The client authentication type, either "oauth" (default) or "basic" auth
-
-        if (strlen($this->getSystemSetting("login_option")) == 0) {
-            $this->login_option = 'oauth';
-        }
+        $this->basic_id = $this->getSystemSetting("basic_name");
+        $this->basic_secret = $this->getSystemSetting("basic_secret");
+        $this->login_option = $this->getSystemSetting('auth_type');    // The client authentication type, either "OAuth2"  or "Basic Auth" auth
 
 
         // namespace for session variables
@@ -107,8 +105,6 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
         if ($this->login_option == 'oauth') {
            $this->_login_oauth();
 
-        } elseif ($this->login_option == 'basic') {
-            $this->_login_basic();
         }
     }
 
@@ -210,18 +206,6 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
     }
 
     /**
-     * Login to API Gateway with Basic Auth
-     * 
-     * @author Egidia Cenko
-     * @access protected
-     * @return void
-     */
-    protected function _login_basic() {
-        //? is this function even required?
-        echo "--login logic for auth type: " . $this->login_option . " --";
-    }
-
-    /**
     * Curl SOAP call of E-PIX/gPAS/SAP webservice
     *
     * @author  Christian Erhardt
@@ -290,7 +274,7 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
 
         } elseif ($this->login_option == 'basic') {
             // TODO change UI fields for basic auth 
-            $user_pw = $this->client_id . ":" . $this->client_secret;
+            $user_pw = $this->basic_id . ":" . $this->basic_secret;
 
             //TODO: update according to sap credentials
             $curl_options[CURLOPT_HTTPHEADER] = array("content-type: text/xml; charset=utf-8","Authorization:Basic " . base64_encode($user_pw));

--- a/PseudoService.php
+++ b/PseudoService.php
@@ -6,6 +6,7 @@ use \RCView as RCView;
 
 include_once('SAPPatientSearch.php');
 include_once('EPIX_gPAS.php');
+include_once('CheckDigit.php');
 
 class PseudoService extends \ExternalModules\AbstractExternalModule {
 	public $error;
@@ -50,7 +51,7 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
         $this->client_secret = $this->getSystemSetting("secret");      // The client password assigned to you by the provider
         $this->basic_id = $this->getSystemSetting("basic_name");
         $this->basic_secret = $this->getSystemSetting("basic_secret");
-        $this->login_option = $this->getSystemSetting('auth_type');    // The client authentication type, either "OAuth2"  or "Basic Auth" auth
+        $this->login_option = $this->getSystemSetting('auth_type');    // The client authentication type, either "oauth" (="OAuth2")  or "basic" (="Basic Auth") auth
 
 
         // namespace for session variables
@@ -260,9 +261,7 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
             CURLOPT_PROXYUSERPWD => $this->curl_proxy_auth,
         );
         
-        //TODO: if condition inserted for test
         if ($this->login_option == 'oauth') {
-            // todo: separate oauth logic
             // get access token from session
             if (isset($_SESSION[$this->session]['oauth2_accesstoken'])) {
                 $this->AccessToken = $_SESSION[$this->session]['oauth2_accesstoken'];
@@ -273,7 +272,6 @@ class PseudoService extends \ExternalModules\AbstractExternalModule {
             $curl_options[CURLOPT_HTTPHEADER] = array("content-type: text/xml; charset=utf-8","Authorization:Bearer " . $this->AccessToken);
 
         } elseif ($this->login_option == 'basic') {
-            // TODO change UI fields for basic auth 
             $user_pw = $this->basic_id . ":" . $this->basic_secret;
 
             //TODO: update according to sap credentials

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ This modul uses these components:
 | SAP Scope             | SAP search Scope (OIDC)          |
 | use proxy             | use REDCap system proxy for http(s) |
 
+
+**Note**: For development within Docker (using the [redcap-docker-compose](https://github.com/123andy/redcap-docker-compose/tree/master) repository), the `allowed REDCap domain` should be set to `localhost` (default) so that the `login()` method in the file [`PseudoService.php`](./PseudoService.php) can work properly.
 ## Project Configuration
 
 - gPAS domain: specifiy gPAS domain for creating studyIDs
 - additional fields for setting the user rights for specific roles:
   ![](docs/project_config1.png)
+  **Note:** In your project, select `Designer` and `+ Create` the instruments `tc_access` and `tc_impexp` in order to make the external module accessible.

--- a/config.json
+++ b/config.json
@@ -220,6 +220,12 @@
             "type": "password"
         },
         {
+            "key": "login_option",
+            "name": "Authentication Login Type (default: oauth)",
+            "required": false,
+            "type": "text"
+        },
+        {
             "key": "gpas_url",
             "name": "gPAS API URL",
             "required": true,

--- a/config.json
+++ b/config.json
@@ -202,6 +202,34 @@
             "type": "text"
         },
         {
+            "key": "auth_type",
+            "name": "Login Authentication Type",
+            "required": true,
+            "type": "dropdown",
+            "choices": [
+              {
+                "value": "oauth",
+                "name": "OAuth2"
+              },
+              {
+                "value": "basic",
+                "name": "Basic Auth"
+              }
+            ]
+        },
+        {
+            "key": "basic_name",
+            "name": "Basic Auth username",
+            "required": true,
+            "type": "password"
+        },
+        {
+            "key": "basic_secret",
+            "name": "Basic Auth secret",
+            "required": true,
+            "type": "password"
+        },
+        {
             "key": "authorization_url",
             "name": "Authorization Server URL",
             "required": true,
@@ -218,12 +246,6 @@
             "name": "OAuth2 Cient secret",
             "required": true,
             "type": "password"
-        },
-        {
-            "key": "login_option",
-            "name": "Authentication Login Type (default: oauth)",
-            "required": false,
-            "type": "text"
         },
         {
             "key": "gpas_url",

--- a/index.php
+++ b/index.php
@@ -987,7 +987,7 @@ if ($module->getSystemSetting('auth_type') == 'basic') {
     // ID stored in known_ID (which can be either MPI or Pat-ID)
     ?>        
         <h5>Pseudonym erzeugen</h5>
-        <form style="max-width:700px;" method="post" action="<?php echo ($module->moduleIndex); ?>">
+        <form style="max-width:750px;" method="post" action="<?php echo ($module->moduleIndex); ?>">
             <div class="form-group row">
                 <label for="known_ID" class="col-sm-2 col-form-label"> Pat. ID <br>(10-stellig)</label>
                 <div class="col-sm-5">

--- a/index.php
+++ b/index.php
@@ -884,7 +884,7 @@ require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 // ================================================================================================
 // display navigation
 // ================================================================================================
-if (PseudoService::isAllowed('search') && $module->getSystemSetting('auth_type') == 'lala') {
+if (PseudoService::isAllowed('search') && $module->getSystemSetting('auth_type') == 'oauth') {
 ?>
       <ul class="nav nav-pills">
         <li class="nav-item">
@@ -993,12 +993,12 @@ if ($module->getSystemSetting('auth_type') == 'basic') {
     // ID stored in known_ID (which can be either MPI or Pat-ID)
     ?>        
         <h5>Pseudonym erzeugen</h5>
-        <form style="max-width:750px;" method="post" action="<?php echo ($module->moduleIndex); ?>">
+        <form style="max-width:700px;" method="post" action="<?php echo ($module->moduleIndex); ?>">
             <div class="form-group row">
                 <label for="known_ID" class="col-sm-2 col-form-label"> Pat. ID <br>(10-stellig)</label>
                 <div class="col-sm-5">
                     <input type="text" class="form-control" id="known_ID" name="known_ID" value="<?php echo $_POST['known_ID']; ?>">
-                    <span id="error-msg" style="color:red; display:none;">Ungültige Eingabe: Pat.-IDs beginnen nicht mit 0</span>
+                    <span id="error-msg" style="color:red; display:none;">Pat-IDs dürfen nicht mit 0 beginnen.</span>
                 </div>
             </div>
             <div class="form-group row">

--- a/index.php
+++ b/index.php
@@ -228,6 +228,19 @@ if (count($_POST) > 0 && isset($_POST['submit'])) {
   } // search
 
   // ================================================================================================
+    // gpas_only logic for PSN creation
+    // ================================================================================================
+    if ($sMode == 'gpas_only' && PseudoService::isAllowed('create')) {
+        $sPSN = $oPseudoService->getOrCreatePseudonymFor($_POST['known_ID']);
+        // redcap log
+        Logging::logEvent('', $module->getModuleName(), "OTHER", '', $_POST['known_ID'].": ".$sPSN, "known_ID: psn created");
+        // save pseudonym in REDCap study
+        $oPseudoService->createREDCap($sPSN);  
+        // redcap log
+        Logging::logEvent('', $module->getModuleName(), "OTHER", '', $sPSN, "PSN retrieved"); 
+    }
+
+  // ================================================================================================
   // create mode
   // ================================================================================================
   if ($sMode == 'create' && PseudoService::isAllowed('create')) {
@@ -894,6 +907,12 @@ if (PseudoService::isAllowed('search')) {
           <a class="nav-link<?php if ($sMode == 'import') print (' active" aria-current="page"'); else print ('"'); ?> href="<?php echo ($module->moduleIndex); ?>&mode=import">Import</a>
         </li>
 <?php   } ?>
+<?php   // ! new tab for gPAS only logic, i.e. generate pseudonym based on knowledge of user about the required ID (either MPI or pat ID)
+        if (PseudoService::isAllowed('create')) { ?>
+        <li class="nav-item">
+          <a class="nav-link<?php if ($sMode == 'gpas_only') print (' active" aria-current="page"'); else print ('"'); ?> href="<?php echo ($module->moduleIndex); ?>&mode=gpas_only">PSN erzeugen</a>
+        </li>
+<?php   } ?>
       </ul><br />
 <?php
 
@@ -964,6 +983,29 @@ if (PseudoService::isAllowed('search')) {
     <?php
     } // end search mode 
 } // end isAllowed('search')
+
+
+// ! mode gpas_only should have the same access rights as create?
+// vars: MPI stored in known_ID (which can be either MPI or Pat-ID)
+if ($sMode == 'gpas_only'
+    && PseudoService::isAllowed('create')) { ?>
+    <h5>Pseudonym erzeugen</h5>
+    <form style="max-width:700px;" method="post" action="<?php echo ($module->moduleIndex); ?>">
+    <div class="form-group row">
+      <label for="ish_id" class="col-sm-2 col-form-label"> MPI</label>
+      <div class="col-sm-5">
+        <input type="text" class="form-control" id="known_ID" name="known_ID" value="<?php echo $_POST['known_ID']; ?>">
+      </div>
+    </div>
+    <div class="form-group row">
+      <div class="col-sm-offset-2 col-sm-5">
+        <button type="submit" class="btn btn-secondary" name="submit">Generieren</button>
+      </div>
+    </div>
+    <input type="hidden" name="mode" value="gpas_only">
+    </form>
+<?php
+} // end gpas_only mode 
 
 // ================================================================================================
 // display create form

--- a/index.php
+++ b/index.php
@@ -38,12 +38,6 @@ $oSAPPatientSearch = new SAPPatientSearch();
 // login
 $oSAPPatientSearch->login();
 
-// redirect to data entry page after login
-if (isset($_SESSION[$oSAPPatientSearch->session]['redirect'])) {
-    $redirect = $_SESSION[$oSAPPatientSearch->session]['redirect'];
-    unset($_SESSION[$oSAPPatientSearch->session]['redirect']);
-    redirect(APP_PATH_WEBROOT."DataEntry/index.php?".$redirect);
-}
 
 // E-PIX/gPAS class
 $oPseudoService = new EPIX_gPAS();

--- a/index.php
+++ b/index.php
@@ -234,8 +234,14 @@ if (count($_POST) > 0 && isset($_POST['submit'])) {
             $sPSN = $oPseudoService->getOrCreatePseudonymFor($patID);
             // redcap log
             Logging::logEvent('', $module->getModuleName(), "OTHER", '', $patID.": ".$sPSN, "known_ID: psn created");
-            // save pseudonym in REDCap study
-            $oPseudoService->createREDCap($sPSN,'', $_POST['known_ID']);  
+
+            if ($module->getProjectSetting("save_sap_id") == true) {
+                // save pseudonym + sap id from provided field in REDCap study
+                $oPseudoService->createREDCap($sPSN,'', $_POST['known_ID']);  
+            } else {
+                // save pseudonym in REDCap study
+                $oPseudoService->createREDCap($sPSN); 
+            }
             // redcap log
             Logging::logEvent('', $module->getModuleName(), "OTHER", '', $sPSN, "PSN retrieved"); 
         }


### PR DESCRIPTION
- allowence of basic auth for gpas (adaption of curl call and separation of oauth and basic logic)
- include gpas only logic: single view of pseudonym generation where user is asked to input a 10 digits number (i.e. patient id and corresponding check digit); live validation via JavaScript through regex and displaying user feedback for IDs with a leading zero
![grafik](https://github.com/user-attachments/assets/779f6d32-9821-4b86-91fb-ecda046f53c1)
- 10 digits input is required by user, internally only the pat id is used for pseudonym generation
- add logic to store the sap id (i.e. 10 digit user input) in a field in the record
