### PR TITLE
add more user-friendly information

### DIFF
--- a/config.json
+++ b/config.json
@@ -189,7 +189,7 @@
           },
           {
               "key": "sap_id_field",
-              "name": "field to store SAP-ID",
+              "name": "field to store SAP-ID <br><small style='color:#da0000;'>field needs to be marked as identifying</small></b style='color:black'> ",
               "type": "field-list",
               "autocomplete": true,
               "super-users-only": true,

--- a/index.php
+++ b/index.php
@@ -1022,7 +1022,7 @@ if ($sMode == 'psn_erzeugen' &&
             </label>
                 <div class="col-sm-5">
                     <input type="text" class="form-control" id="known_ID" name="known_ID" value="<?php echo $_POST['known_ID']; ?>">
-                    <span id="error-msg-leading-0" style="color:red; display:none;">Pat-IDs dürfen nicht mit 0 beginnen.</span>
+                    <span id="error-msg-leading-0" style="color:red; display:none;">Pat-IDs dürfen nicht mit 0 beginnen.<br>Geben Sie die ID ab der 2. Stelle an<br>(damit wird die Eingabe insg. 9-stellig)</span>
                 </div>
             </div>
             <div class="form-group row">


### PR DESCRIPTION
The following changes were made in order to provide more information to the user.

1) The person who is responsible for the project design needs to mark identifying fields as such (depending on the user access rights, only deidentified data is exportable then):
2) Users who received an ID with a leading zero might not know directly that the ID can still be an existing 9 digit ID (is it relevant to highlight this information in such detail?)

Image acc. to 1)
![user_hint](https://github.com/user-attachments/assets/c157ab12-4537-42a6-8f9c-8dd7b5b83bde)

Image acc to 2)
![input_zero_v1](https://github.com/user-attachments/assets/6e43ce92-8bd6-42f4-b4be-0b154dfbf995)
